### PR TITLE
Configuration

### DIFF
--- a/init.js
+++ b/init.js
@@ -17,6 +17,12 @@ const CSS_TOOLTIP_CELL = CSS_PREFIX + 'tooltip-cell';
 const CSS_TOOLTIP_TOGGLE = CSS_PREFIX + 'toggle';
 const CSS_TOOLTIP_ACTIVE = CSS_PREFIX + 'active';
 
+const VISIBILITY_STATUSES = {
+  OWNER: 'OWNER',
+  FRIENDLY: 'FRIENDLY',
+  ALL: 'ALL',
+};
+
 const tooltipElem = document.createElement('div');
 tooltipElem.classList.add(CSS_TOOLTIP);
 
@@ -27,6 +33,19 @@ tooltipElem.appendChild(tooltipName);
 const tooltipDataContainer = document.createElement('div');
 tooltipDataContainer.classList.add(CSS_DATA);
 tooltipElem.appendChild(tooltipDataContainer);
+
+Hooks.once('init', () => {
+  game.settings.register('illandril-token-tooltips', 'visibility-status', {
+    name: game.i18n.localize('illandril-token-tooltips.settings.visibility-status.name'),
+    hint: game.i18n.localize('illandril-token-tooltips.settings.visibility-status.hint'),
+    scope: 'world',
+    config: true,
+    restricted: true,
+    choices: VISIBILITY_STATUSES,
+    default: VISIBILITY_STATUSES.FRIENDLY,
+    type: String,
+  });
+})
 
 Hooks.once('ready', () => {
   // Workaround for the hover spam issue: https://gitlab.com/foundrynet/foundryvtt/-/issues/3506
@@ -212,7 +231,17 @@ function shouldShowTooltip(token) {
   if (game.user.isGM) {
     return true;
   }
-  return token.data.disposition === TOKEN_DISPOSITIONS.FRIENDLY;
+  const visibility = game.settings.get('illandril-token-tooltips', 'visibility-status');
+  switch (visibility) {
+    case VISIBILITY_STATUSES.FRIENDLY:
+      return token.data.disposition === TOKEN_DISPOSITIONS.FRIENDLY;
+    case VISIBILITY_STATUSES.OWNER:
+      return token.actor.permission === ENTITY_PERMISSIONS.OWNER;
+    case VISIBILITY_STATUSES.ALL:
+      return true;
+    default:
+      return false;
+  }
 }
 
 function showSpellSlot(ssArr, level, slots) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,5 +4,7 @@
   "illandril-token-tooltips.tooltipShown": "Shown in Tooltip",
   "illandril-token-tooltips.tooltipNotShown": "Not Shown in Tooltip",
   "illandril-token-tooltips.settings.visibility-status.name": "Visibility Status",
-  "illandril-token-tooltips.settings.visibility-status.hint": "Tooltips will only be show for users with token permissions that match this value."
+  "illandril-token-tooltips.settings.visibility-status.hint": "Tooltips will only be show for users with token permissions that match this value.",
+  "illandril-token-tooltips.settings.show-all.name": "Show all tooltips on <Alt>",
+  "illandril-token-tooltips.settings.show-all.hint": "Show all available tooltips when holding the <Alt> key down."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,5 +2,7 @@
   "illandril-token-tooltips.pactAbbreviation": "P",
   "illandril-token-tooltips.tooltipSwitch": "Show in Tooltip",
   "illandril-token-tooltips.tooltipShown": "Shown in Tooltip",
-  "illandril-token-tooltips.tooltipNotShown": "Not Shown in Tooltip"
+  "illandril-token-tooltips.tooltipNotShown": "Not Shown in Tooltip",
+  "illandril-token-tooltips.settings.visibility-status.name": "Visibility Status",
+  "illandril-token-tooltips.settings.visibility-status.hint": "Tooltips will only be show for users with token permissions that match this value."
 }

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,9 @@
 .illandril-token-tooltips--tooltip {
   position: absolute;
-  display: none;
+  display: block;
   background: rgba(255, 255, 255, 0.75);
   border-radius: 2px;
   border: 2px solid rgba(255, 255, 255, 0.9);
-}
-
-.illandril-token-tooltips--tooltip.illandril-token-tooltips--show {
-  display: block;
 }
 
 .illandril-token-tooltips--name {


### PR DESCRIPTION
Add some configuration options.

- Allow configuring tooltip visibility based on token ownership/disposition (Fixes #8)
- Allow showing all available tooltips on holding `<Alt>` key

The second change is a little more invasive, since it requires moving away from the single global container to individual elements for each tooltip. If you want me to split the changes into separate PRs, that's doable, but there will be some merge conflicts if it's done that way, which is why I bundled them both.